### PR TITLE
Ajout de la recherche par date

### DIFF
--- a/src/main/java/com/lacouf/JiraCloudConnector.java
+++ b/src/main/java/com/lacouf/JiraCloudConnector.java
@@ -2,6 +2,7 @@ package com.lacouf;
 
 import lombok.SneakyThrows;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.net.URI;
@@ -24,8 +25,9 @@ public class JiraCloudConnector {
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
 
-        var params = ("?jql=project = \"" + JiraConfig.PROJECT + "\" AND Sprint = \"" + JiraConfig.SPRINT_NAME
-                + "\" AND timespent != 0" + "&maxResults=" + JiraConfig.MAX_RESULTS + "&fields=" + JiraConfig.FIELDS)
+        var params = ("?jql=project = \"" + JiraConfig.PROJECT +
+                (JiraConfig.SPRINT_NAME != null ? "\" AND Sprint = \"" + JiraConfig.SPRINT_NAME : "") +
+                "\" AND timespent != 0" + "&maxResults=" + JiraConfig.MAX_RESULTS + "&fields=" + JiraConfig.FIELDS)
                 .replace(" ", "%20")
                 .replace("\"", "%22");
 
@@ -72,19 +74,33 @@ public class JiraCloudConnector {
                             .taskId(obj.getString("key"))
                             .userTask(getSummary(obj))
                             .userName(log.getJSONObject("author").getString("displayName"))
-                            .logWorkDescription(log.getJSONObject("comment").getJSONArray("content").getJSONObject(0).getJSONArray("content").getJSONObject(0).getString("text"))
+                            .logWorkDescription(getComment(log))
                             .logWorkDate(log.getString("created"))
                             .logWorkSeconds(log.getInt("timeSpentSeconds"))
                             .logWorkDateTime(LocalDateTime.parse(log.getString("created").replaceFirst("\\.[0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]", "")))
                             .build());
                 }
                 catch (Exception e) {
-                    System.err.println("Caught \"" + e.getMessage() + "\" on a worklog from " + obj.getString("key"));
+                    System.err.println("Caught \"" + e.getMessage() + "\" on a worklog from " + obj.getString("key") + " by " + log.getJSONObject("author").getString("displayName"));
                 }
             });
         });
 
         return list;
+    }
+
+    private String getComment(JSONObject log) {
+        String value;
+        try {
+            value = log.getJSONObject("comment").getJSONArray("content").getJSONObject(0).getJSONArray("content").getJSONObject(0).getString("text");
+        }
+        catch (Exception e) {
+            if (JiraConfig.INCLUDE_EMPTY_COMMENT)
+                value = "--- EMPTY COMMENT ---";
+            else
+                throw e;
+        }
+        return value;
     }
 
     private String getSummary(JSONObject obj) {

--- a/src/main/java/com/lacouf/JiraConfig.java
+++ b/src/main/java/com/lacouf/JiraConfig.java
@@ -6,7 +6,7 @@ public class JiraConfig {
     public static final String API_TOKEN = "ST3MGsubFza4iCxsjxkS3FEC"; //https://id.atlassian.com/manage-profile/security pour générer
     public static final String SITE_URL = "https://420-565-eq1.atlassian.net";
     public static final String PROJECT = "EQ3";
-    public static final String SPRINT_NAME = null;
+    public static final String SPRINT_NAME = "Sprint 3"; //si null, recherche par date seulement
     public static final String START_DATE = "01-01-1900";
     public static final boolean INCLUDE_EMPTY_COMMENT = true;
 

--- a/src/main/java/com/lacouf/JiraConfig.java
+++ b/src/main/java/com/lacouf/JiraConfig.java
@@ -2,11 +2,13 @@ package com.lacouf;
 
 public class JiraConfig {
 
-    public static final String USER_EMAIL = "TON_EMAIL_ICI";
-    public static final String API_TOKEN = "TA_CLE_D_API_ICI"; //https://id.atlassian.com/manage-profile/security pour générer
+    public static final String USER_EMAIL = "simonllandry@gmail.com";
+    public static final String API_TOKEN = "ST3MGsubFza4iCxsjxkS3FEC"; //https://id.atlassian.com/manage-profile/security pour générer
     public static final String SITE_URL = "https://420-565-eq1.atlassian.net";
     public static final String PROJECT = "EQ3";
-    public static final String SPRINT_NAME = "Sprint 3";
+    public static final String SPRINT_NAME = null;
+    public static final String START_DATE = "01-01-1900";
+    public static final boolean INCLUDE_EMPTY_COMMENT = true;
 
     //Do not change
     public static final String FIELDS = "id,worklog,parent,summary";

--- a/src/main/java/com/lacouf/JiraConfig.java
+++ b/src/main/java/com/lacouf/JiraConfig.java
@@ -2,8 +2,8 @@ package com.lacouf;
 
 public class JiraConfig {
 
-    public static final String USER_EMAIL = "simonllandry@gmail.com";
-    public static final String API_TOKEN = "ST3MGsubFza4iCxsjxkS3FEC"; //https://id.atlassian.com/manage-profile/security pour générer
+    public static final String USER_EMAIL = "";
+    public static final String API_TOKEN = ""; //https://id.atlassian.com/manage-profile/security pour générer
     public static final String SITE_URL = "https://420-565-eq1.atlassian.net";
     public static final String PROJECT = "EQ3";
     public static final String SPRINT_NAME = "Sprint 3"; //si null, recherche par date seulement

--- a/src/main/java/com/lacouf/JiraReporter.java
+++ b/src/main/java/com/lacouf/JiraReporter.java
@@ -1,5 +1,7 @@
 package com.lacouf;
 
+import lombok.SneakyThrows;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -9,25 +11,21 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class JiraReporter {
-    private Map<String, Double> hoursPerUser = new HashMap<>();
+    private final Map<String, Double> hoursPerUser = new HashMap<>();
 
+    @SneakyThrows
     public void printRestReport(List<LogWorkEntry> entries) {
-        printCsvReport(entries, "01-01-1900");
+        printCsvReport(entries, JiraConfig.START_DATE);
     }
 
     public void printCsvReport(List<LogWorkEntry> entries, String dateFrom) {
         LocalDate from = parseDate(dateFrom);
         final Map<String, List<LogWorkEntry>> result =
-            entries.stream()
-                   .filter(wl -> wl.getLogWorkDateTime().toLocalDate().isAfter(from))
-                   .collect(
-                       Collectors.groupingBy(
-                           wl -> wl.getUserName()
-                       )
-                   );
-        result.entrySet()
-              .stream()
-              .forEach(e -> printEntry(e));
+                entries.stream()
+                        .filter(wl -> wl.getLogWorkDateTime().toLocalDate().isAfter(from))
+                        .collect(Collectors.groupingBy(LogWorkEntry::getUserName));
+
+        result.entrySet().forEach(this::printEntry);
     }
 
     private LocalDate parseDate(String dateFrom) {
@@ -39,20 +37,18 @@ public class JiraReporter {
     private void printEntry(Map.Entry<String, List<LogWorkEntry>> e) {
         System.out.println(e.getKey());
         hoursPerUser.put(e.getKey(), 0.0);
-        e.getValue()
-         .stream()
-         .forEach(log -> printEntryDetail(e.getKey(), log));
+        e.getValue().forEach(log -> printEntryDetail(e.getKey(), log));
         System.out.println("total hours : " + hoursPerUser.get(e.getKey()));
         System.out.println();
     }
 
     private void printEntryDetail(String user, LogWorkEntry log) {
-        final float hours = Float.valueOf(log.getLogWorkSeconds()) / 3600;
+        final float hours = (float) log.getLogWorkSeconds() / 3600;
         System.out.println("\t" + log.getTaskId() + " "
-            + log.getLogWorkDescription() + " "
-            + log.getLogWorkDate() + " "
-            + log.getUserTask() + " "
-            + hours);
+                + log.getLogWorkDescription() + " "
+                + log.getLogWorkDate() + " "
+                + log.getUserTask() + " "
+                + hours);
         double newHours = hoursPerUser.get(user) + hours;
         hoursPerUser.put(user, newHours);
     }


### PR DESCRIPTION
- Permet de setter le sprint à null pour rechercher uniquement par date, ou d'utiliser les deux pour préciser la recherches

- Options pour inclure les worklogs sans commentaires dans le résultat